### PR TITLE
Fix issue with `min_samp` becoming of `float` type

### DIFF
--- a/df-aggregator.py
+++ b/df-aggregator.py
@@ -307,11 +307,12 @@ def process_data(database_name, epsilon, min_samp):
                 n_points = len(X)
 
                 if min_samp == "auto":
-                    min_samp = max(3, round(0.05 * n_points, 0))
-                elif min_samp.isnumeric():
-                    min_samp = int(min_samp)
-                else:
+                    min_samp = round(0.05 * n_points)
+                elif not min_samp.isnumeric():
                     break
+
+                min_samp = max(3, min_samp)
+                min_samp = int(min_samp)
 
                 if epsilon == "auto":
                     epsilon = autoeps_calc(X)


### PR DESCRIPTION
It turns out `round(x, 0)` might return value of `float` type leading to `TypeError: min_samples must be an instance of int, not float.`. Let's take care of that and also guard user input for minimum of 3 samples. Thanks to @jhonnybonny for reporting.