### PR TITLE
Attempting updates for newer czml3

### DIFF
--- a/df-aggregator.py
+++ b/df-aggregator.py
@@ -31,7 +31,7 @@ from lxml import etree
 from sklearn.cluster import DBSCAN
 from sklearn.preprocessing import StandardScaler, minmax_scale
 from geojson import MultiPoint, Feature, FeatureCollection
-from czml3 import Packet, Document, Preamble
+from czml3 import Packet, Document
 from czml3.properties import Position, Polyline, PolylineMaterial, PolylineOutlineMaterial, PolylineDashMaterial, Color, Material
 from multiprocessing import Process, Queue
 from bottle import route, run, request, get, put, response, redirect, template, static_file
@@ -44,7 +44,6 @@ if (version_info.major != 3 or version_info.minor < 6):
           str(version_info.minor) + ", which is no longer supported.")
     print("Your python version is out of date, please update to 3.6 or newer.")
     quit()
-
 
 DBSCAN_Q = Queue()
 DBSCAN_WAIT_Q = Queue()
@@ -643,7 +642,7 @@ def write_rx_czml():
     gray = [128, 128, 128, 255]
     receiver_point_packets = []
     lob_packets = []
-    top = Preamble(name="Receivers")
+    top = Packet(id="document", name="Receivers", version="1.0")
 
     rx_properties = {
         "verticalOrigin": "BOTTOM",
@@ -724,7 +723,7 @@ def wr_aoi_czml():
     response.set_header(
         'Cache-Control', 'no-cache, no-store, must-revalidate, max-age=0')
     aoi_packets = []
-    top = Preamble(name="AOIs")
+    top = Packet(id="document", name="AOIs", version="1.0")
     area_of_interest_properties = {
         "granularity": 0.008722222,
         "height": 0,

--- a/df-aggregator.py
+++ b/df-aggregator.py
@@ -568,7 +568,7 @@ def write_czml(best_point, all_the_points, ellipsedata, plotallintersects, eps):
         }
     }
 
-    top = Preamble(name="Geolocation Data")
+    top = Packet(id="document", name="Geolocation Data", version="1.0")
     all_point_packets = []
     best_point_packets = []
     ellipse_packets = []
@@ -623,7 +623,7 @@ def write_czml(best_point, all_the_points, ellipsedata, plotallintersects, eps):
                                               **ellipse_properties, **ellipse_info},
                                           position={"cartographicDegrees": [x[3], x[4], 0]}))
 
-    return Document([top] + best_point_packets + all_point_packets + ellipse_packets).dumps(separators=(',', ':'))
+    return Document(packets=[top] + best_point_packets + all_point_packets + ellipse_packets).dumps()
 
 
 ###############################################
@@ -712,8 +712,7 @@ def write_rx_czml():
                                                      **rx_properties, **rx_icon},
                                                  position={"cartographicDegrees": [x.longitude, x.latitude, 15]}))
 
-        return Document([top] + receiver_point_packets + lob_packets).dumps(separators=(',', ':'))
-
+        return Document(packets=[top] + receiver_point_packets + lob_packets).dumps()
 
 ###############################################
 # Writes aoi.czml used by the WebUI
@@ -774,7 +773,7 @@ def wr_aoi_czml():
                                   ellipse={**aoi_properties, **aoi_info},
                                   position={"cartographicDegrees": [aoi['longitude'], aoi['latitude'], 0]}))
 
-    return Document([top] + aoi_packets).dumps(separators=(',', ':'))
+    return Document(packets=[top] + aoi_packets).dumps()
 
 
 ###############################################

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ bottle-websocket>=0.2.9
 geojson>=2.5.0
 numpy>=1.13.3
 lxml>=4.2.1
-czml3>=0.5.4
+czml3>=2.3.4
 scikit_learn>=0.23.2


### PR DESCRIPTION
I've not actually ran real receivers into the application, only loaded the interface. From what I can tell Preamble was removed in newer czml3 as well as separators not being needed and dumps() being okay on it's own. 