### PR TITLE
Fix min_samp type conversion error in process_data

### DIFF
--- a/df-aggregator.py
+++ b/df-aggregator.py
@@ -371,9 +371,10 @@ def process_data(database_name, epsilon, min_samp):
                     min_samp = round(0.05 * n_points)
                 elif not min_samp.isnumeric():
                     break
+                else:
+                    min_samp = int(min_samp)
 
                 min_samp = max(3, min_samp)
-                min_samp = int(min_samp)
 
                 if epsilon == "auto":
                     epsilon = autoeps_calc(X)


### PR DESCRIPTION
When min_samp is passed as a numeric string from query parameters, it needs to be converted to int before the max() comparison. Added else clause to convert numeric strings to int, preventing TypeError when comparing string with int.