### PR TITLE
Add gzip compression middleware for web server

### DIFF
--- a/df-aggregator.py
+++ b/df-aggregator.py
@@ -1084,6 +1084,7 @@ class GzipMiddleware:
         'application/x-javascript',
         'application/czml',
     )
+    _MIN_SIZE = 512
 
     def __init__(self, wsgi_app):
         self.app = wsgi_app
@@ -1140,6 +1141,10 @@ class GzipMiddleware:
         finally:
             if hasattr(result, 'close'):
                 result.close()
+
+        if len(body) < self._MIN_SIZE:
+            start_response(status, headers)
+            return [body]
 
         compressed = gzip.compress(body, compresslevel=6)
 

--- a/df-aggregator.py
+++ b/df-aggregator.py
@@ -17,6 +17,7 @@
 #     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from dataclasses import dataclass
+import gzip
 import vincenty as v
 import numpy as np
 from scipy.spatial.distance import cdist
@@ -39,7 +40,7 @@ from czml3 import Packet, Document, CZML_VERSION
 from czml3.properties import Position, PositionList, Polyline, PolylineMaterial, PolylineOutlineMaterial, PolylineDashMaterial, Color
 import queue
 from multiprocessing import Process, Queue, set_start_method
-from bottle import route, run, request, get, put, response, redirect, template, static_file
+from bottle import route, run, request, get, put, response, redirect, template, static_file, app as bottle_app
 from bottle.ext.websocket import GeventWebSocketServer, websocket
 
 from sys import version_info
@@ -963,11 +964,86 @@ def handle_interest_areas(action):
 
 
 ###############################################
+# WSGI middleware that gzip-compresses responses
+# for clients that advertise Accept-Encoding: gzip.
+# Skips WebSocket upgrades and already-encoded
+# or non-compressible content types.
+###############################################
+class GzipMiddleware:
+    _COMPRESSIBLE = (
+        'text/',
+        'application/json',
+        'application/javascript',
+        'application/x-javascript',
+        'application/czml',
+    )
+
+    def __init__(self, wsgi_app):
+        self.app = wsgi_app
+
+    def __call__(self, environ, start_response):
+        if environ.get('HTTP_UPGRADE', '').lower() == 'websocket':
+            return self.app(environ, start_response)
+
+        if 'gzip' not in environ.get('HTTP_ACCEPT_ENCODING', ''):
+            return self.app(environ, start_response)
+
+        captured_status = []
+        captured_headers = []
+
+        def _start_response(status, headers, exc_info=None):
+            if exc_info:
+                raise exc_info[1].with_traceback(exc_info[2])
+            captured_status.append(status)
+            captured_headers.append(headers)
+
+        result = self.app(environ, _start_response)
+
+        status = captured_status[0]
+        headers = captured_headers[0]
+
+        content_type = ''
+        already_encoded = False
+        for name, value in headers:
+            name_lower = name.lower()
+            if name_lower == 'content-type':
+                content_type = value.lower()
+            elif name_lower == 'content-encoding':
+                already_encoded = True
+
+        compressible = (
+            not already_encoded and
+            any(ct in content_type for ct in self._COMPRESSIBLE)
+        )
+
+        if not compressible:
+            start_response(status, headers)
+            return result
+
+        body = b''.join(result)
+        if hasattr(result, 'close'):
+            result.close()
+
+        compressed = gzip.compress(body, compresslevel=6)
+
+        new_headers = [
+            (name, value) for name, value in headers
+            if name.lower() not in ('content-length', 'content-encoding')
+        ]
+        new_headers.append(('Content-Encoding', 'gzip'))
+        new_headers.append(('Content-Length', str(len(compressed))))
+        new_headers.append(('Vary', 'Accept-Encoding'))
+
+        start_response(status, new_headers)
+        return [compressed]
+
+
+###############################################
 # Starts the Bottle webserver.
 ###############################################
 def start_server(ipaddr="127.0.0.1", port=8080):
     try:
-        run(host=ipaddr, port=port, quiet=True,
+        run(app=GzipMiddleware(bottle_app()), host=ipaddr, port=port, quiet=True,
             server=GeventWebSocketServer, debug=True)
     except OSError:
         print(f"Port {port} seems to be in use. Please select another port or " +

--- a/df-aggregator.py
+++ b/df-aggregator.py
@@ -1074,10 +1074,7 @@ def handle_interest_areas(action):
 
 
 ###############################################
-# WSGI middleware that gzip-compresses responses
-# for clients that advertise Accept-Encoding: gzip.
-# Skips WebSocket upgrades and already-encoded
-# or non-compressible content types.
+# Gzip compression WSGI middleware
 ###############################################
 class GzipMiddleware:
     _COMPRESSIBLE = (
@@ -1092,7 +1089,8 @@ class GzipMiddleware:
         self.app = wsgi_app
 
     def __call__(self, environ, start_response):
-        if environ.get('HTTP_UPGRADE', '').lower() == 'websocket':
+        if (environ.get('HTTP_UPGRADE', '').lower() == 'websocket' and
+                'upgrade' in environ.get('HTTP_CONNECTION', '').lower()):
             return self.app(environ, start_response)
 
         if 'gzip' not in environ.get('HTTP_ACCEPT_ENCODING', ''):
@@ -1103,11 +1101,18 @@ class GzipMiddleware:
 
         def _start_response(status, headers, exc_info=None):
             if exc_info:
-                raise exc_info[1].with_traceback(exc_info[2])
-            captured_status.append(status)
-            captured_headers.append(headers)
+                try:
+                    if captured_status:
+                        raise exc_info[1].with_traceback(exc_info[2])
+                finally:
+                    exc_info = None
+            captured_status[:] = [status]
+            captured_headers[:] = [headers]
 
         result = self.app(environ, _start_response)
+
+        if not captured_status:
+            return result
 
         status = captured_status[0]
         headers = captured_headers[0]
@@ -1130,15 +1135,17 @@ class GzipMiddleware:
             start_response(status, headers)
             return result
 
-        body = b''.join(result)
-        if hasattr(result, 'close'):
-            result.close()
+        try:
+            body = b''.join(result)
+        finally:
+            if hasattr(result, 'close'):
+                result.close()
 
         compressed = gzip.compress(body, compresslevel=6)
 
         new_headers = [
             (name, value) for name, value in headers
-            if name.lower() not in ('content-length', 'content-encoding')
+            if name.lower() not in ('content-length', 'content-encoding', 'vary')
         ]
         new_headers.append(('Content-Encoding', 'gzip'))
         new_headers.append(('Content-Length', str(len(compressed))))


### PR DESCRIPTION
Wraps the Bottle WSGI app with GzipMiddleware, which compresses
text-based responses (HTML, JSON, JS, CSS, CZML) for clients that
send Accept-Encoding: gzip. WebSocket upgrades and already-encoded
or binary responses are passed through unchanged. Uses compresslevel=6
for a good speed/ratio balance and adds Vary: Accept-Encoding.

https://claude.ai/code/session_01FW9ujQYhMEuqxpNscNEbFt